### PR TITLE
Change the 'is-ready' message after profiler changed its postMessage API

### DIFF
--- a/src/taskprofiler/taskprofiler.mjs
+++ b/src/taskprofiler/taskprofiler.mjs
@@ -457,7 +457,7 @@ async function injectProfile(profile, params = '') {
    * @param {MessageEvent} event
    */
   const listener = ({ data }) => {
-    if (data?.name === 'is-ready') {
+    if (data?.name === 'ready:response') {
       console.log('The profiler is ready. Injecting the profile.');
       isReady = true;
       const message = {
@@ -472,7 +472,7 @@ async function injectProfile(profile, params = '') {
   window.addEventListener('message', listener);
   while (!isReady) {
     await new Promise((resolve) => setTimeout(resolve, 100));
-    profilerWindow.postMessage({ name: 'is-ready' }, profilerOrigin);
+    profilerWindow.postMessage({ name: 'ready:request' }, profilerOrigin);
   }
 
   window.removeEventListener('message', listener);

--- a/src/visualizer/visualizer.mjs
+++ b/src/visualizer/visualizer.mjs
@@ -509,7 +509,7 @@ function setupProfilerButton(taskGroups, taskClusterURL) {
      * @param {MessageEvent} event
      */
     const listener = ({ data }) => {
-      if (data?.name === 'is-ready') {
+      if (data?.name === 'ready:response') {
         console.log('The profiler is ready. Injecting the profile.');
         isReady = true;
         const message = {
@@ -524,7 +524,7 @@ function setupProfilerButton(taskGroups, taskClusterURL) {
     window.addEventListener('message', listener);
     while (!isReady) {
       await new Promise((resolve) => setTimeout(resolve, 100));
-      profilerWindow.postMessage({ name: 'is-ready' }, profilerOrigin);
+      profilerWindow.postMessage({ name: 'ready:request' }, profilerOrigin);
     }
 
     window.removeEventListener('message', listener);


### PR DESCRIPTION
This is changed in https://github.com/firefox-devtools/profiler/pull/5148. Previously we were using 'is-ready' for both the request and the response. Now we are using two distinct messages on both for clarity.