### PR TITLE
Pull Google COMET scores from final evals GCP bucket

### DIFF
--- a/src/training/training.mjs
+++ b/src/training/training.mjs
@@ -1,3 +1,4 @@
+/* vim: set tabstop=2 shiftwidth=2: */
 import {
   exposeAsGlobal,
   getElement,
@@ -425,22 +426,22 @@ function updateScores() {
 }
 
 /** @type {Promise<EvalResults>} */
-let cometScores;
-function getCometScores() {
-  if (cometScores) {
-    return cometScores;
+let cometScores = {};
+function getCometScores(langPair) {
+  console.log("cometscores", cometScores);
+  if (cometScores[langPair]) {
+    return cometScores[langPair];
   }
-  cometScores = _getCometScores();
-  return cometScores;
+  cometScores[langPair] = _getCometScores(langPair);
+  return cometScores[langPair];
 }
 
 /**
  * @returns {Promise<EvalResults>}
  */
-async function _getCometScores() {
-  const response = await fetch(
-    'https://raw.githubusercontent.com/mozilla/firefox-translations-models/main/evaluation/comet-results.json',
-  );
+async function _getCometScores(langPair) {
+  const url = `https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/final-evals/${langPair}__flores200-plus__google__v2__latest__comet22.metrics.json`
+  const response = await fetch(url,);
 
   return await response.json();
 }
@@ -478,13 +479,13 @@ async function _getCometScores() {
  * @param {string} taskId
  */
 async function updateCometTD(td, langPair, score, provider, dataset, taskId) {
-  const cometResults = await getCometScores();
+  const cometResults = await getCometScores(langPair);
   while (td.lastChild) {
     td.removeChild(td.lastChild);
   }
 
   let percentageDisplay;
-  const googleScore = cometResults[langPair]?.['flores-test']?.['google'];
+  const googleScore = cometResults['score'];
   // const googleScore = getAverageGoogleCometScore(cometResults, langPair);
   const percentage = 100 * (1 - googleScore / score);
   const sign = percentage >= 0 ? '+' : '';


### PR DESCRIPTION
Google scores from translations-models repo are outdated and started to be quite different for some language pairs. I changed the source to the metrics stored in the GCP bucket from final evals. There is not a file with all the scores, so each language pair has to be pulled individually.

I tried with this parameters and it seems to work: https://gregtatum.github.io/taskcluster-tools/src/training/?dashboardName=HBS+experiments&taskGroupIds=UQOEYK4tRbu-5H8OvxYG0g%2CD_whZEMOTVeFzJE-SlbT8A%2CcgPTZlW4TNiTooy36I1dZw%2CcPA9Em-fQaWoydtWn_bWPg%2CJUGXE5qtQH6gmLkruTXVog&showAll=false&taskGroupNames=%5B%22%22%2C%22%22%2C%22%22%2C%22%22%5D